### PR TITLE
feat:  #59 投稿削除機能の実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -36,6 +36,12 @@ class PostsController < ApplicationController
     end
   end
 
+  def destroy
+    post = current_user.posts.find(params[:id])
+    post.destroy!
+    redirect_to posts_path, success: t('defaults.flash_message.deleted', item: Post.model_name.human), status: :see_other
+  end
+
   private
   def post_params
     params.require(:post).permit(:location_name, :address, :start_hour, :start_minute, :end_hour, :end_minute, :description, :wifi, :electricity, :site_url, :genre, :quiet_level, :post_image, :post_image_cache)

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -26,6 +26,9 @@
               <%= link_to edit_post_path(post) do%>
                 <i class="fa-solid fa-pencil"></i>
               <% end %>
+              <%= link_to post_path(post),data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } do %>
+              <i class="fa-solid fa-trash"></i>
+              <% end %>
             </div>
           <% end %>
           </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -5,7 +5,10 @@
 <% if current_user.own?(@post) %>
   <div class='ms-auto'>
     <%= link_to edit_post_path(@post) do%>
-    <i class="fa-solid fa-pencil"></i>
+    <i class="fa-solid fa-pencil mr-3"></i>
+    <% end %>
+    <%= link_to @post_path(@post),data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } do %>
+    <i class="fa-solid fa-trash"></i>
     <% end %>
   </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   root "static_pages#top"
   resources :users, only: %i[new create]
-  resources :posts, only: %i[index new create show edit update]
+  resources :posts, only: %i[index new create show edit update destroy]
   get "login", to: "user_sessions#new"
   post "login", to: "user_sessions#create"
   delete "logout", to: "user_sessions#destroy"


### PR DESCRIPTION
### issue番号
close #59 

### やったこと
投稿の削除機能実装

### 実装内容

- ルーティングの設定
- アクションをコントローラーに定義
- ビューの追加

### できたこと
削除ボタンを押すと削除できるようになった。