### PR TITLE
feat: #63 Google Map APIの導入と設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,8 @@ gem 'carrierwave', '2.2.2'
 
 gem 'kaminari'
 
+gem "geocoder"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.1)
       railties (>= 6.0.0)
+    csv (3.3.0)
     date (3.3.4)
     debug (1.9.2)
       irb (~> 1.10)
@@ -156,6 +157,9 @@ GEM
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (1.1.0)
+    geocoder (1.8.3)
+      base64 (>= 0.1.0)
+      csv (>= 3.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hashie (5.0.0)
@@ -404,6 +408,7 @@ DEPENDENCIES
   dotenv-rails
   enum_help
   fog-aws
+  geocoder
   jbuilder
   jsbundling-rails
   kaminari

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -1,0 +1,4 @@
+class MapsController < ApplicationController
+  def index
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,4 +1,8 @@
+require 'geocoder'
+
 class Post < ApplicationRecord
+  geocoded_by :address
+  after_validation :geocode, if: :address_changed?
   validates :location_name, presence: true, length: { maximum: 255 }
   validates :address, presence: true
   validates :start_hour, :end_hour, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than: 24 }

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -1,0 +1,16 @@
+<h2>gmap</h2>
+<div id="map" class="h-[37.5rem] w-full"></div>
+
+<script>
+let map
+
+function initMap(){
+  geocoder = new google.maps.Geocoder()
+
+  map = new google.maps.Map(document.getElementById('map'), {
+    center: {lat: 35.681236, lng:139.767125},
+    zoom: 15,
+  });
+}
+</script>
+<script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAY-uCnCZyIPM0shv1n28aT8nfJCrZaFHI&callback=initMap" async defer></script>

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -13,4 +13,4 @@ function initMap(){
   });
 }
 </script>
-<script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAY-uCnCZyIPM0shv1n28aT8nfJCrZaFHI&callback=initMap" async defer></script>
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAP_API_KEY'] %>&callback=initMap" async defer></script>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -7,7 +7,7 @@
     <%= link_to edit_post_path(@post) do%>
     <i class="fa-solid fa-pencil mr-3"></i>
     <% end %>
-    <%= link_to @post_path(@post),data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } do %>
+    <%= link_to post_path(@post),data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } do %>
     <i class="fa-solid fa-trash"></i>
     <% end %>
   </div>
@@ -82,6 +82,10 @@
           <td class="border px-2 py-2">詳細コメント</td>
         <td class="border px-2 py-2"><%= @post.description %></td>
         </tr>
+        <tr>
+          <td class="border px-2 py-2">地図</td>
+        <td class="border px-2 py-2"><div id="map" class="h-[37.5rem] w-full"></div></td>
+        </tr>
       </tbody>
     </table>
     </div>
@@ -89,3 +93,36 @@
       <%= link_to t('.go_back_to_list'), posts_path, class: "items-center bg-button hover:bg-green-700 text-white rounded px-5 py-3 mr-3" %>
     <div>
 </div>
+
+<!-- Googleマップ表示用の Javascript -->
+<script>
+  function initMap(){
+    // 地図の位置情報(緯度・経度)を取得
+    let mapPosition = {lat: <%= @post.latitude || 35.681236 %> , lng: <%= @post.longitude || 139.767125 %> };
+    let map = new google.maps.Map(document.getElementById('map'), {
+      zoom: 15,
+      center: mapPosition
+    });
+    let transitLayer = new google.maps.TransitLayer();
+    transitLayer.setMap(map);
+
+    let contentString = '【住所】<%= @post.address %>';
+    let infowindow = new google.maps.InfoWindow({
+      content: contentString
+    });
+
+    let marker = new google.maps.Marker({
+      position: mapPosition,
+      map: map,
+      title: contentString
+    });
+
+    marker.addListener('click', function(){
+      infowindow.open(map, marker);
+    });
+  }
+  </script>
+
+  <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAP_API_KEY'] %>&callback=initMap" async defer></script>
+
+

--- a/app/views/shared/_btmnav.html.erb
+++ b/app/views/shared/_btmnav.html.erb
@@ -1,7 +1,7 @@
 <nav id="buttom-navbar" class="fixed z-50 w-full h-16 max-w-lg -translate-x-1/2 bg-primary border-lg border-gray-200 rounded-lg bottom-4 left-1/2">
   <ul class="flex justify-center items-center">
     <li class="md:flex-grow-0 md:w-1/4 text-center hover:bg-white hover:rounded-full">
-      <%= link_to root_path do %>
+      <%= link_to maps_path do %>
       <button class="group inline-block text-center m-2">
       <i class="fa-solid fa-map-location"></i>
         <p class="icon-text font-Spicyrice"><%= t('btmnav.map') %></p>

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,5 @@
+Geocoder.configure(
+  lookup: :google,
+  use_https: true,
+  api_key: ENV['GOOGLE_MAP_API_KEY'],
+)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   root "static_pages#top"
   resources :users, only: %i[new create]
   resources :posts, only: %i[index new create show edit update destroy]
+  resources :maps, only: %i[index]
   get "login", to: "user_sessions#new"
   post "login", to: "user_sessions#create"
   delete "logout", to: "user_sessions#destroy"

--- a/db/migrate/20241113052141_rename_longitude_to_longtitude_in_posts.rb
+++ b/db/migrate/20241113052141_rename_longitude_to_longtitude_in_posts.rb
@@ -1,0 +1,5 @@
+class RenameLongitudeToLongtitudeInPosts < ActiveRecord::Migration[7.2]
+  def change
+    rename_column :posts, :longitude, :longtitude
+  end
+end

--- a/db/migrate/20241113053103_rename_longtitude_to_longitude_in_posts.rb
+++ b/db/migrate/20241113053103_rename_longtitude_to_longitude_in_posts.rb
@@ -1,0 +1,5 @@
+class RenameLongtitudeToLongitudeInPosts < ActiveRecord::Migration[7.2]
+  def change
+    rename_column :posts, :longtitude, :longitude
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_08_020748) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_13_053103) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
### issue番号
close #63 

### やったこと
Google Map APIの設定と導入

### 実装内容

- API キーを取得する為にGoogle アカウントの登録
- プロジェクトの作成
- ビューに記述を追加

### できたこと
投稿詳細画面で住所から位置情報を取得して地図を表示できるようにした。

### 参考にした記事
[Rails6 / Google Map API】初学者向け！Ruby on Railsで簡単にGoogle Map APIの導入する](https://qiita.com/nagase_toya/items/e49977efb686ed05eadb)
[Railsで地図 投稿 地名検索 一覧表示 GoogleMapsAPI(JavaScript) gemなし](https://qiita.com/mt-blue-sou/items/9a39b3a122a8be5b9b65)