### PR TITLE
fix: エラー修正

### DIFF
--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -1,4 +1,4 @@
-<div id="map" class="h-[37.5rem] w-full"></div>
+<div id="map" class=" w-full" style="height: 600px;"></div>
 <script>
   function initMap() {
     // 地図要素を取得する（マーカーを表示させるために必要）
@@ -14,9 +14,9 @@
     // マーカーを追加（Postの情報からマーカーを追加する）
     <% @posts.each do |post| %>
       new google.maps.Marker({
-        position: {lat: <%= post.latitude %>, lng: <%= post.longitude %>}, 
+        position: { lat: <%= post.latitude || 35.6803997 %>, lng: <%= post.longitude || 139.7690174 %> }, 
         map: map,
-        title: '<%= j post.location_name %>'
+        title: '<%= post.location_name.gsub("'", "\\'") %>'
       });
     <% end %>
   }


### PR DESCRIPTION
### やったこと
本番環境で一覧表示の地図が表示されなかったのでその修正

本番環境では、特にデータに予期しない特殊文字（例えばシングルクオート）が含まれていると、JavaScriptの構文エラーが発生し、地図や他の機能が正常に動作しなくなることがあります。gsub("'", "\\'") を使ってシングルクオートをエスケープすることで、こうしたエラーを防いでいる。

変更前
`<% @posts.each do |post| %>
      new google.maps.Marker({
        position: {lat: <%= post.latitude %>, lng: <%= post.longitude %>}, 
        map: map,
        title: '<%= j post.location_name %>'
      });
    <% end %>`

変更後
`<% @posts.each do |post| %>
      new google.maps.Marker({
        position: { lat: <%= post.latitude || 35.6803997 %>, lng: <%= post.longitude || 139.7690174 %> }, 
        map: map,
        title: '<%= post.location_name.gsub("'", "\\'") %>'
      });
    <% end %>`

他にもいくつか試したがエラーが改善されなかったので、これが原因だと思われる。
登録していたデータが、longitudeとlatitudeがnilだったためエラーを引き起こした。
デフォルトの座標を登録したことで改善された。