### PR TITLE
fix: #81 未ログイン時でも一覧画面が正常に表示されるように修正

### DIFF
--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -21,7 +21,7 @@
           <div class="flex ml-2 items-center">
             <i class="fa-solid fa-circle-user"></i>
             <p class="text-left ml-2 mr-2 w-auto"><%= post.user.username %></p>
-            <% if current_user.own?(post) %>
+            <% if current_user&.own?(post) %>
             <div class='ms-auto'>
               <%= link_to edit_post_path(post) do%>
                 <i class="fa-solid fa-pencil"></i>


### PR DESCRIPTION
Closes #81 

# 概要
未ログイン時に一覧表示が正常に表示されるように修正
# やったこと
未ログイン時に一覧表示が正常に表示されるように修正

変更前
`<% if current_user.own?(post) %>`
このコードでは、current_user が nil である場合、current_user.own?(post) を実行しようとしてエラーが発生します。current_user が未ログインのユーザー（nil）の場合、own? メソッドを呼び出すと NoMethodError になります。

変更後
`<% if current_user&.own?(post) %>`
この変更では、Rubyのセーフナビゲーション演算子 (&.) を使用しています。セーフナビゲーション演算子は、current_user が nil の場合に own? メソッドを呼び出さず、nil を返します。したがって、current_user が未ログインの状態（nil）であっても、エラーを発生させずに条件を評価できます。

結論
&. を使うことで、current_user が nil であってもエラーを発生させずに処理できるため、未ログインのユーザーが一覧画面にアクセスした場合にエラーを防げるようになります

# やらないこと
なし
# できるようになること（ユーザ目線）
ログインしていなくても一覧表示が見られるようになった
# できなくなること（ユーザ目線）
なし
# 動作確認
ローカル環境ではエラーが発生せず適切に表示された。
本番環境はマージした後確認。
# その他
[ぼっち演算子の使い方](https://qiita.com/tomada/items/78bb419f5c99f0dc033d)
# 関連Issue
関連Issue: #81
