### PR TITLE
add: #99 マップ画面に検索機能の追加

### DIFF
--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -1,6 +1,7 @@
 class MapsController < ApplicationController
   skip_before_action :require_login, only: %i[index]
   def index
-    @posts = Post.all
+    @q = Post.ransack(params[:q])
+    @posts = @q.result.includes(:user).page(params[:page])
   end
 end

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -1,3 +1,9 @@
+<div class="mt-4">
+    <form>
+        <%= render 'posts/search_form'%>
+    </form>
+</div>
+
 <div id="map" class="h-[37.5rem] w-full"></div>
 <!-- モーダルのHTML -->
 <dialog id="spot_modal" class="rounded-2xl shadow-2xl w-full sm:max-w-md md:max-w-2xl lg:max-w-xl xl:max-w2xl max-h-[80%] sm:max-h-[40%] md:max-h-[50%] lg:max-h-[60%] mx-auto items-center">


### PR DESCRIPTION
Closes #99 

# 概要
マップ画面に検索機能の追加
# やったこと
マップ画面に検索機能の追加
# やらないこと
なし
# できるようになること（ユーザ目線）
マップ画面からでも一覧画面と同じように検索できるようになった。
# できなくなること（ユーザ目線）
なし
# 動作確認
ローカルでは機能確認済み
# その他
なし
# 関連Issue
関連Issue: #82  #99 
