### PR TITLE
fix: #101 一覧表示で文字がカードからはみ出ているので修正

### DIFF
--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -10,10 +10,10 @@
       <span class="inline-block items-center gap-x-1.5 py-0.5 px-1 mt-2 rounded-full text-xs font-medium border border-gray-800 text-gray-800">
         <%= I18n.t("activerecord.attributes.post.genre.#{post.genre}") %>
       </span>
-      <p class="md:text-lg text-base w-full mt-2" style="white-space: nowrap; word-wrap: break-word;" title="<%= post.address %>">
-        <%= t('.address') %> <%= post.address %>
+      <p class="md:text-lg text-base w-full mt-2" title="<%= post.address %>">
+        <%= t('.address') %><%= post.address %>
       </p>
-      <p class="md:text-lg text-base w-full mt-2" style="white-space: nowrap; word-wrap: break-word;" title="<%= post.address %>">
+      <p class="md:text-lg text-base w-full mt-2 break-word;" title="<%= post.description %>">
          <%= post.description.truncate(50) %>
       </p>
       <div class="flex items-center mt-2">


### PR DESCRIPTION
Closes #101 

# 概要
一覧表示で文字がカードからはみ出ているので修正
# やったこと
一覧表示で文字がカードからはみ出ているので修正
# やらないこと
なし
# できるようになること（ユーザ目線）
なし
# できなくなること（ユーザ目線）
なし
# 動作確認
なし
# その他
なし
# 関連Issue
関連Issue: #101 
