### PR TITLE
add:　動的OGPの作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,8 @@ gem "kaminari"
 gem "geocoder"
 
 gem "ransack"
+
+gem "meta-tags"
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,6 +204,8 @@ GEM
       net-smtp
     marcel (1.0.4)
     matrix (0.4.2)
+    meta-tags (2.22.1)
+      actionpack (>= 6.0.0, < 8.1)
     mime-types (3.6.0)
       logger
       mime-types-data (~> 3.2015)
@@ -418,6 +420,7 @@ DEPENDENCIES
   jbuilder
   jsbundling-rails
   kaminari
+  meta-tags
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.1)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,23 +3,23 @@ module ApplicationHelper
     assign_meta_tags if display_meta_tags.blank?
     display_meta_tags
   end
-    
+
   def assign_meta_tags(options = {})
     defaults = {
-      site: 'サイト名',
-      title: 'デフォルトのタイトル',
-      description: 'デフォルトのページの説明',
-      keywords: 'デフォルトのページキーワード',
-      image: image_url('logo.png') # デフォルト画像
+      site: "サイト名",
+      title: "デフォルトのタイトル",
+      description: "デフォルトのページの説明",
+      keywords: "デフォルトのページキーワード",
+      image: image_url("logo.png") # デフォルト画像
     }
     options.reverse_merge!(defaults)
     site = options[:site]
     title = options[:title]
     description = options[:description]
     keywords = options[:keywords]
-    image = options[:image].presence || image_url('logo.png')
+    image = options[:image].presence || image_url("logo.png")
     configs = {
-      separator: '|',
+      separator: "|",
       reverse: true,
       site:,
       title:,
@@ -27,10 +27,10 @@ module ApplicationHelper
       keywords:,
       canonical: request.original_url,
       icon: {
-        href: image_url('logo.png')
+        href: image_url("logo.png")
         },
       og: {
-        type: 'website',
+        type: "website",
         title: title.presence || site,
         description: nil,  # OGPのdescriptionは空にする
         url: request.original_url,
@@ -39,11 +39,10 @@ module ApplicationHelper
         },
       twitter: {
         site:,
-        card: 'summary_large_image',
+        card: "summary_large_image",
         image:
          }
     }
       set_meta_tags(configs)
   end
 end
-

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,38 @@
 module ApplicationHelper
+  def show_meta_tags
+    assign_meta_tags if display_meta_tags.blank?
+    display_meta_tags
+  end
+
+  def default_meta_tags
+    def default_meta_tags
+    {
+      site: 'zenfocus',
+      title: '集中できる静かな場所を探す',
+      reverse: true,
+      separator: '|',   #Webサイト名とページタイトルを区切るために使用されるテキスト
+      description: '勉強や作業に最適な静かな場所を簡単に見つけられるサービスです。',
+      keywords: '静かな場所, 勉強, 作業, カフェ, 図書館, zenfocus',   #キーワードを「,」区切りで設定する
+      canonical: request.original_url,   #優先するurlを指定する
+      noindex: ! Rails.env.production?,
+      icon: [                    #favicon、apple用アイコンを指定する
+        { href: image_url('favicon.ico') },
+        { href: image_url('icon.jpg'), rel: 'apple-touch-icon', sizes: '180x180', type: 'image/jpg' },
+      ],
+      og: {
+        site_name: 'zenfocus',
+        title: '集中できる静かな場所を探す | zenfocus',
+        description: '勉強や作業にぴったりな静かな場所を地図検索で簡単に探せるサービスです。', 
+        type: 'website',
+        url: request.original_url,
+        image: image_url('ogp.png'),
+        locale: 'ja_JP',
+      },
+      twitter: {
+        card: 'summary_large_image',
+      }
+    }
+  end
+  end
 end
+

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,36 +3,48 @@ module ApplicationHelper
     assign_meta_tags if display_meta_tags.blank?
     display_meta_tags
   end
-
-  def default_meta_tags
-    def default_meta_tags
-    {
-      site: 'zenfocus',
-      title: '集中できる静かな場所を探す',
-      reverse: true,
-      separator: '|',   #Webサイト名とページタイトルを区切るために使用されるテキスト
-      description: '勉強や作業に最適な静かな場所を簡単に見つけられるサービスです。',
-      keywords: '静かな場所, 勉強, 作業, カフェ, 図書館, zenfocus',   #キーワードを「,」区切りで設定する
-      canonical: request.original_url,   #優先するurlを指定する
-      noindex: ! Rails.env.production?,
-      icon: [                    #favicon、apple用アイコンを指定する
-        { href: image_url('favicon.ico') },
-        { href: image_url('icon.jpg'), rel: 'apple-touch-icon', sizes: '180x180', type: 'image/jpg' },
-      ],
-      og: {
-        site_name: 'zenfocus',
-        title: '集中できる静かな場所を探す | zenfocus',
-        description: '勉強や作業にぴったりな静かな場所を地図検索で簡単に探せるサービスです。', 
-        type: 'website',
-        url: request.original_url,
-        image: image_url('ogp.png'),
-        locale: 'ja_JP',
-      },
-      twitter: {
-        card: 'summary_large_image',
-      }
+    
+  def assign_meta_tags(options = {})
+    defaults = {
+      site: 'サイト名',
+      title: 'デフォルトのタイトル',
+      description: 'デフォルトのページの説明',
+      keywords: 'デフォルトのページキーワード',
+      image: image_url('logo.png') # デフォルト画像
     }
-  end
+    options.reverse_merge!(defaults)
+    site = options[:site]
+    title = options[:title]
+    description = options[:description]
+    keywords = options[:keywords]
+    image = options[:image].presence || image_url('logo.png')
+    configs = {
+      separator: '|',
+      reverse: true,
+      site:,
+      title:,
+      description:,
+      keywords:,
+      canonical: request.original_url,
+      icon: {
+        href: image_url('logo.png')
+        },
+      og: {
+        type: 'website',
+        title: title.presence || site,
+        url: request.original_url,
+        image:,
+        site_name: site
+        description: nil  # OGPのdescriptionは空にする
+        },
+      twitter: {
+        site:,
+        card: 'summary_large_image',
+        image:
+        description: nil  # Twitterのdescriptionも空にする
+         }
+    }
+      set_meta_tags(configs)
   end
 end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,16 +32,15 @@ module ApplicationHelper
       og: {
         type: 'website',
         title: title.presence || site,
+        description: nil,  # OGPのdescriptionは空にする
         url: request.original_url,
         image:,
         site_name: site
-        description: nil  # OGPのdescriptionは空にする
         },
       twitter: {
         site:,
         card: 'summary_large_image',
         image:
-        description: nil  # Twitterのdescriptionも空にする
          }
     }
       set_meta_tags(configs)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,6 +3,7 @@
   <head>
     <title><%= content_for(:title) || "Zenfocus" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
+     <%= show_meta_tags %>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,3 +1,4 @@
+<% assign_meta_tags title: @post.location_name,  image: @post.post_image %>
 <div class='container rounded-xl shadow-xl p-6 max-w-full md:max-w-3xl mx-auto my-10 border border-white bg-base-100'>
   <div class="flex justify-between items-center">
     <div class="flex items-center">

--- a/config/initializers/meta_tags.rb
+++ b/config/initializers/meta_tags.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+# Use this setup block to configure all options available in MetaTags.
+MetaTags.configure do |config|
+  # How many characters should the title meta tag have at most. Default is 70.
+  # Set to nil or 0 to remove limits.
+  # config.title_limit = 70
+
+  # When true, site title will be truncated instead of title. Default is false.
+  # config.truncate_site_title_first = false
+
+  # Add HTML attributes to the <title> HTML tag. Default is {}.
+  # config.title_tag_attributes = {}
+
+  # Natural separator when truncating. Default is " " (space character).
+  # Set to nil to disable natural separator.
+  # This also allows you to use a whitespace regular expression (/\s/) or
+  # a Unicode space (/\p{Space}/).
+  # config.truncate_on_natural_separator = " "
+
+  # Maximum length of the page description. Default is 300.
+  # Set to nil or 0 to remove limits.
+  # config.description_limit = 300
+
+  # Maximum length of the keywords meta tag. Default is 255.
+  # config.keywords_limit = 255
+
+  # Default separator for keywords meta tag (used when an Array passed with
+  # the list of keywords). Default is ", ".
+  # config.keywords_separator = ', '
+
+  # When true, keywords will be converted to lowercase, otherwise they will
+  # appear on the page as is. Default is true.
+  # config.keywords_lowercase = true
+
+  # When true, the output will not include new line characters between meta tags.
+  # Default is false.
+  # config.minify_output = false
+
+  # When false, generated meta tags will be self-closing (<meta ... />) instead
+  # of open (`<meta ...>`). Default is true.
+  # config.open_meta_tags = true
+
+  # List of additional meta tags that should use "property" attribute instead
+  # of "name" attribute in <meta> tags.
+  # config.property_tags.push(
+  #   'x-hearthstone:deck',
+  # )
+end


### PR DESCRIPTION
Closes #103 

# 概要
動的OGPの作成
# やったこと
動的OGPの作成
# やらないこと
なし
#できるようになること
Xでシェアした際にOGPが作成できるようになった。
# できなくなること（ユーザ目線）
なし
# 動作確認
ローカル環境でogpが作成されたのを確認済み
# その他
なし
# 関連Issue
関連Issue: #103
