### PR TITLE
fix: ユーザー登録後自動ログインに変更

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,8 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to root_path,  success: t("users.create.success")
+      auto_login(@user)
+      redirect_to posts_path,  success: t("users.create.success")
     else
       flash.now[:danger] =  t("users.create.failure")
       render :new, status: :unprocessable_entity


### PR DESCRIPTION
Closes #127 

# 概要
ユーザー登録後自動ログインに変更
# やったこと
ユーザー登録後自動ログインに変更
# やらないこと
なし
# できるようになること（ユーザ目線）
ユーザー登録の後に、再度情報を入力してログインする必要がなくなった。
# できなくなること（ユーザ目線）
なし
# 動作確認
ローカル環境では動作確認済み
# その他
なし
# 関連Issue
関連Issue: #127
