### PR TITLE
fix:時間入力欄の変更の動作確認

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -50,6 +50,6 @@ class PostsController < ApplicationController
 
   private
   def post_params
-    params.require(:post).permit(:location_name, :address, :start_hour, :start_minute, :end_hour, :end_minute, :description, :wifi, :electricity, :site_url, :genre, :quiet_level, :post_image, :post_image_cache)
+    params.require(:post).permit(:location_name, :address, :start_time, :end_time, :description, :wifi, :electricity, :site_url, :genre, :quiet_level, :post_image, :post_image_cache)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -24,8 +24,8 @@ class Post < ApplicationRecord
 
   def business_hours
     if start_time.present? && end_time.present?
-    start_formatted = start_time.strftime('%H時%M分')
-    end_formatted = end_time.strftime('%H時%M分')
+    start_formatted = start_time.strftime("%H時%M分")
+    end_formatted = end_time.strftime("%H時%M分")
     "#{start_formatted} - #{end_formatted}"
     else
     "営業時間未設定"

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -5,8 +5,6 @@ class Post < ApplicationRecord
   after_validation :geocode, if: :address_changed?
   validates :location_name, presence: true, length: { maximum: 255 }
   validates :address, presence: true
-  validates :start_hour, :end_hour, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than: 24 }
-  validates :start_minute, :end_minute, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than: 60 }
   validates :description, presence: true, length: { maximum: 65_535 }
   validates :quiet_level, presence: true
   validates :genre, presence: true
@@ -25,7 +23,13 @@ class Post < ApplicationRecord
   very_quiet: 5 }
 
   def business_hours
-    "#{start_hour}時#{format('%02d', start_minute)}分 - #{end_hour}時#{format('%02d', end_minute)}分"
+    if start_time.present? && end_time.present?
+    start_formatted = start_time.strftime('%H時%M分')
+    end_formatted = end_time.strftime('%H時%M分')
+    "#{start_formatted} - #{end_formatted}"
+    else
+    "営業時間未設定"
+    end
   end
 
   def self.ransackable_attributes(auth_object = nil)

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with model: @post do |f| %>
     <%= render 'shared/error_messages', object: f.object %>
     <div class='mt-10 mb-6 flex flex-col items-center'>
-      <%= f.label :genre, "スポットのジャンル",class: 'label w-full lg:w-2/3 mb-2' %>
+      <%= f.label :genre,"スポットのジャンル(必須)", class: 'label w-full lg:w-2/3 mb-2' %>
       <%= f.select :genre, Post.genres_i18n.invert.to_a, { include_blank: "未選択" },
                   class: "form-input #{'border-red-500' if f.object.errors[:genre].present?}  bg-card-body bg-base-100 rounded-md border border-accent py-2 px-3 w-full lg:w-2/3" %>
     </div>
@@ -18,14 +18,20 @@
 
     <div class='mb-6 flex flex-col items-center'>
       <div class="grid grid-cols-2 gap-2 w-full lg:w-2/3">
-        <div class="flex flex-col w-full">
+        <div class="flex flex-col w-full md:w-1/2">
           <%= f.label :start_time,  class: 'label mb-2' %>
-          <%= f.datetime_select :start_time, { include_blank: "選択してください" }, class: 'bg-card-body bg-base-100 rounded-md border border-accent py-2 px-3' %>
+          <p class = 'text-xs mb-2'>*何も入力しない場合は0時がデフォルトになります。</p>
+        <div class="flex gap-2">
+          <%= f.time_select :start_time, { include_blank: true,  minute_step: 15, prompt: true, ignore_date: true}, class: 'bg-card-body bg-base-100 rounded-md border border-accent py-2 px-3 w-full', value: "" %>
+        </div>
         </div>
 
-        <div class="flex flex-col w-1/2">
+        <div class="flex flex-col w-full md:w-1/2">
           <%= f.label :end_time,  class: 'label mb-2' %>
-          <%= f.datetime_select :end_time, { include_blank: "選択してください" }, class: 'bg-card-body bg-base-100 rounded-md border border-accent py-2 px-3' %>
+          <p class = 'text-xs mb-2'>*何も入力しない場合は0時がデフォルトになります。</p>
+        <div class="flex gap-2">
+          <%= f.time_select :end_time, { include_blank: true,  minute_step: 15 ,prompt: true, ignore_date: true }, class: 'bg-card-body bg-base-100 rounded-md border border-accent py-2 px-3 w-full', value: "" %>
+        </div>
         </div>
       </div>
     </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -31,18 +31,16 @@ ja:
         password: パスワード
         password_confirmation: パスワード確認
       post:
-        location_name: 場所の名前
-        address: 住所
-        start_hour: 営業開始時間
-        end_hour:  営業終了時間
-        start_minute: 営業開始時間(分)
-        end_minute: 営業終了時間(分)
-        description: 詳細
-        quiet_level: 静かさレベル
+        location_name: 場所の名前(必須)
+        address: 住所(必須)
+        start_time: 営業開始時間 
+        end_time:  営業終了時間
+        description: 詳細(必須)
+        quiet_level: 静かさレベル(必須)
         post_image: 画像
         electricity: 電源
         site_url: サイトURL
-        genre: スポットのジャンル
+        genre: スポットのジャンル(必須)
 
         genre:
           cafe: カフェ

--- a/db/migrate/20241224095259_change_start_and_end_time_to_time_in_posts.rb
+++ b/db/migrate/20241224095259_change_start_and_end_time_to_time_in_posts.rb
@@ -1,0 +1,7 @@
+class ChangeStartAndEndTimeToTimeInPosts < ActiveRecord::Migration[7.2]
+  def change
+    # datetime から time 型に変更
+    change_column :posts, :start_time, :time, null: true
+    change_column :posts, :end_time, :time, null: true
+  end
+end

--- a/db/migrate/20241224101233_change_start_and_end_time_to_allow_null_in_posts.rb
+++ b/db/migrate/20241224101233_change_start_and_end_time_to_allow_null_in_posts.rb
@@ -1,0 +1,8 @@
+class ChangeStartAndEndTimeToAllowNullInPosts < ActiveRecord::Migration[7.2]
+  def change
+    def change
+      change_column :posts, :start_time, :time, null: true
+      change_column :posts, :end_time, :time, null: true
+    end
+  end
+end

--- a/db/migrate/20241224103200_change_start_and_end_time_to_not_null_in_posts.rb
+++ b/db/migrate/20241224103200_change_start_and_end_time_to_not_null_in_posts.rb
@@ -1,0 +1,6 @@
+class ChangeStartAndEndTimeToNotNullInPosts < ActiveRecord::Migration[7.2]
+  def change
+        change_column_null :posts, :start_time, false
+        change_column_null :posts, :end_time, false  
+  end
+end

--- a/db/migrate/20241224103200_change_start_and_end_time_to_not_null_in_posts.rb
+++ b/db/migrate/20241224103200_change_start_and_end_time_to_not_null_in_posts.rb
@@ -1,6 +1,6 @@
 class ChangeStartAndEndTimeToNotNullInPosts < ActiveRecord::Migration[7.2]
   def change
         change_column_null :posts, :start_time, false
-        change_column_null :posts, :end_time, false  
+        change_column_null :posts, :end_time, false
   end
 end

--- a/db/migrate/20241225054610_change_start_and_end_time_null_constraint_in_posts.rb
+++ b/db/migrate/20241225054610_change_start_and_end_time_null_constraint_in_posts.rb
@@ -1,0 +1,6 @@
+class ChangeStartAndEndTimeNullConstraintInPosts < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :posts, :start_time, true
+    change_column_null :posts, :end_time, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_20_144029) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_25_054610) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -43,8 +43,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_20_144029) do
     t.integer "genre", null: false
     t.integer "quiet_level", null: false
     t.string "post_image"
-    t.datetime "start_time"
-    t.datetime "end_time"
+    t.time "start_time"
+    t.time "end_time"
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 


### PR DESCRIPTION
Closes #132 
# 概要
時間入力欄の変更の動作確認
# やったこと
時間入力欄の変更の動作確認
# やらないこと
なし
# できるようになること（ユーザ目線）
なし
# できなくなること（ユーザ目線）
なし
# 動作確認
未入力時にデータベースにデフォルトの値ではなく、未入力のままで登録されるようになった。
# その他
なし
# 関連Issue
関連Issue: #132
